### PR TITLE
Superuser and info importing for GCC

### DIFF
--- a/proloauth_client/utils.py
+++ b/proloauth_client/utils.py
@@ -10,7 +10,14 @@ from proloauth_client import models
 
 
 # List of user attributes that are updated from the oauth endpoint
-USER_SYNC_KEYS = ['username', 'is_superuser', 'is_staff', 'email']
+USER_SYNC_KEYS = [
+    'username',
+    'is_staff',
+    'is_superuser',
+    'first_name',
+    'last_name',
+    'email',
+]
 
 
 def gen_auth_state():
@@ -25,7 +32,8 @@ def refresh_token(request, user, data):
 
 def update_user(user, data):
     for key in USER_SYNC_KEYS:
-        setattr(user, key, data['user'][key])
+        if getattr(user, key) in (None, ''):
+            setattr(user, key, data['user'][key])
 
     user.save()
 


### PR DESCRIPTION
Hello,

Fixes prologin/gcc-site#69, fixes prologin/gcc-site#70

I have changed two things : 
- USER_SYNC_KEYS no longer has the superuser status, because it was causing some conflicts, and some more fields were added.
- update_user now has a small NULL check, so that we update the information on GCC's website if and only if there is nothing yet ; it means we can update our info on GCC, and it won't be forced by Prologin.

Since I was not sure what we really wanted to do, I did this, however, we may decide to remove the check on the update_user method, so that Prologin's infos (except the superuser status) are forced onto GCC's website.
We could also choose to keep the check on the update_user method, and add the superuser status back into USER_SYNC_KEYS, as it would mean that if we are superuser on GCC, then we are superuser on GCC no matter the status on Prologin, and if we are not on GCC, but are on Prologin, then we become superuser (which might make sense).

Thank you for your help on these issues.