### PR TITLE
middleware: correct url namespace

### DIFF
--- a/proloauth_client/middleware.py
+++ b/proloauth_client/middleware.py
@@ -34,7 +34,7 @@ class RefreshTokenMiddleware(MiddlewareMixin):
                 },
             )
         except:
-            return HttpResponseRedirect(reverse('proloauth:autologin'))
+            return HttpResponseRedirect(reverse('proloauth_client:autologin'))
 
         if not handle_proloauth_response(request, res):
-            return HttpResponseRedirect(reverse('proloauth:autologin'))
+            return HttpResponseRedirect(reverse('proloauth_client:autologin'))


### PR DESCRIPTION
fix NoReverseMatch error GCC! and finale.prologin.org when Oauth2 token expires.